### PR TITLE
feat: add options `tipHoverable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,15 @@ const QuillToolbarTipOption = {
 
 ### Types and default value
 
-| Option    | Description                                                                                |
-| --------- | ------------------------------------------------------------------------------------------ |
-| direction | The direction of the tooltip display                                                       |
-| delay     | The delay before the tooltip is displayed and hidden in milliseconds.                      |
-| msg       | The message of the tooltip                                                                 |
-| content   | The content of the tooltip                                                                 |
-| className | The class name of the tooltip                                                              |
-| onShow    | Callback when tooltip show. If `onShow` return `undefined`, the tooltip will not be shown. |
+| Option       | Description                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------ |
+| direction    | The direction of the tooltip display                                                       |
+| delay        | The delay before the tooltip is displayed and hidden in milliseconds.                      |
+| msg          | The message of the tooltip                                                                 |
+| content      | The content of the tooltip                                                                 |
+| className    | The class name of the tooltip                                                              |
+| tipHoverable | Display tooltip when tooltip is hovered. Default is `true`.                                |
+| onShow       | Callback when tooltip show. If `onShow` return `undefined`, the tooltip will not be shown. |
 
 ```ts
 interface TooltipOptions {

--- a/src/utils/components.ts
+++ b/src/utils/components.ts
@@ -22,6 +22,7 @@ export interface TooltipOptions {
   delay: number;
   content: HTMLElement;
   className: string | string[];
+  tipHoverable: boolean;
   onShow: (target: HTMLElement) => string | HTMLElement | undefined | null;
 }
 export interface TooltipInstance {
@@ -38,6 +39,7 @@ export const createTooltip = (target: HTMLElement, options: Partial<TooltipOptio
     content,
     direction = 'top',
     className = [],
+    tipHoverable = true,
     onShow,
   } = Object.assign({}, tooltipDefaultOptions, options);
   if (isString(className)) {
@@ -116,7 +118,10 @@ export const createTooltip = (target: HTMLElement, options: Partial<TooltipOptio
       }, delay);
     }
 
-    const eventListeners = [target, tooltip];
+    const eventListeners = [target];
+    if (tipHoverable) {
+      eventListeners.push(tooltip);
+    }
     for (const listener of eventListeners) {
       listener.addEventListener('mouseenter', show);
       listener.addEventListener('mouseleave', hide);


### PR DESCRIPTION
close #2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `tipHoverable` option to tooltips, allowing tooltips to remain visible when hovered over
	- Default behavior set to keep tooltip visible during hover

- **Documentation**
	- Updated README with new tooltip configuration option
	- Improved formatting of documentation tables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->