### PR TITLE
fix: tooltip wrapper doesn't destroy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export class QuillToolbarTip {
           }
           return currentControlResult || result;
         },
+        appendTo: this.quill.container,
       });
       if (instance) {
         this.toolbarTips.push([toolName, instance]);

--- a/src/utils/components.ts
+++ b/src/utils/components.ts
@@ -24,6 +24,7 @@ export interface TooltipOptions {
   className: string | string[];
   tipHoverable: boolean;
   onShow: (target: HTMLElement) => string | HTMLElement | undefined | null;
+  appendTo: HTMLElement;
 }
 export interface TooltipInstance {
   instance: HTMLElement;
@@ -41,6 +42,7 @@ export const createTooltip = (target: HTMLElement, options: Partial<TooltipOptio
     className = [],
     tipHoverable = true,
     onShow,
+    appendTo = document.body,
   } = Object.assign({}, tooltipDefaultOptions, options);
   if (isString(className)) {
     className = ensureArray(className.split(' '));
@@ -98,7 +100,7 @@ export const createTooltip = (target: HTMLElement, options: Partial<TooltipOptio
 
         if (!tooltipContainer) {
           tooltipContainer = document.createElement('div');
-          document.body.appendChild(tooltipContainer);
+          appendTo.appendChild(tooltipContainer);
         }
         tooltipContainer.appendChild(tooltip);
         tooltip.removeEventListener('transitionend', transitionendHandler);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tooltip placement by introducing a configurable `appendTo` option
	- Allows more flexible positioning of tooltips within the application's DOM

- **Improvements**
	- Updated tooltip rendering to support custom container placement
	- Added default tooltip container as `document.body`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->