### PR TITLE
fix: get real `value` of select

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,14 @@ export class QuillToolbarTip {
         ...this.options.defaultTooltipOptions,
         ...config,
         onShow: (target: HTMLElement) => {
-          const currentValue = toolControl.value || '';
+          let currentValue = toolControl.value || '';
+          if (toolControl.tagName.toLowerCase() === 'select') {
+            // When an <option> has no `value` attribute, `select.value` falls back to the
+            // option's text content. To avoid this, read the `value` attribute directly
+            // from the selected option element, which returns null (not the text) when absent.
+            const selectTool = toolControl as HTMLSelectElement;
+            currentValue = selectTool.options[selectTool.selectedIndex]?.getAttribute?.('value') || '';
+          }
 
           // Priority 1: onShow function
           if (config.onShow) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { createTooltip, isString, isUndefined } from './utils';
 
 export interface TooltipItem extends Omit<TooltipOptions, 'onShow'> {
   values?: Record<string, string>;
-  onShow?: (this: Quill, target: HTMLElement, value: string) => ReturnType<TooltipOptions['onShow']>;
+  onShow?: (this: Quill, target: HTMLElement, value: string, toolControl: HTMLButtonElement | HTMLSelectElement) => ReturnType<TooltipOptions['onShow']>;
 }
 
 export interface QuillToolbarTipOptions {
@@ -70,7 +70,7 @@ export class QuillToolbarTip {
 
           // Priority 1: onShow function
           if (config.onShow) {
-            return config.onShow.call(this.quill, target, currentValue);
+            return config.onShow.call(this.quill, target, currentValue, toolControl);
           }
 
           // Priority 2: values mapping


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the tooltip callback to include access to the originating control element, enabling handlers to receive additional context when the tooltip appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->